### PR TITLE
Rewording 9.5.1, Activity 4

### DIFF
--- a/_sources/BikeRental/sorting_SQL.rst
+++ b/_sources/BikeRental/sorting_SQL.rst
@@ -95,7 +95,7 @@ Practice Exercises
     :autograde: unittest
     :dburl: /runestone/books/published/httlads/_static/bikeshare.db
 
-    Get the start and end station IDs for bike trips that are longer 60 minutes or longer, in the order of largest number of seconds first and display the top 40 results.
+    Get the duration, start station ID, and end station ID for bike trips that are 60 minutes or longer, in the order of largest number of seconds first and display the top 40 results.
     ~~~~
 
 


### PR DESCRIPTION
This question currently asks for the start station and end station IDs, but the assert statements require the duration, start station and end station ID. There's also an extra 'longer' in the question. Fixed.